### PR TITLE
Fixing README.md & Adding .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo getcap /usr/bin/hcitool
 
 ### Run the Command line interface (CLI)
 ```
-cd heykube-python/scripts
+cd heykube_python/scripts
 ./heykube_cli.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In order to BTLE scan to work without sudo, you need to run the following:
 
 ```
 # clean up BTLE scan with sudo
-sudo setcap ‘cap_net_raw,cap_net_admin+eip’ /usr/bin/hcitool
+sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/bin/hcitool
 
 # Check that it works
 sudo getcap /usr/bin/hcitool


### PR DESCRIPTION
There's a small error (a dash instead of an underscore) in the path to run the CLI.

On my RPi, the setcap command published in the README can't be run as described because of the quote : 

```console
(heykube_env) pi@raspberrypi:~/heykube_python $ sudo setcap ‘cap_net_raw,cap_net_admin+eip’ /usr/bin/hcitool
fatal error: Invalid argument
usage: setcap [-q] [-v] (-r|-|<caps>) <filename> [ ... (-r|-|<capsN>) <filenameN> ]

 Note <filename> must be a regular (non-symlink) file.
```
